### PR TITLE
fix: remove RestartPolicy

### DIFF
--- a/kube-sec-deploy/assets/setup/demo-api.yaml
+++ b/kube-sec-deploy/assets/setup/demo-api.yaml
@@ -22,7 +22,6 @@ spec:
         ports:
         - containerPort: 9000
           protocol: TCP
-        restartPolicy: Always
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Defaults to Always [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#writing-a-deployment-spec) and was failing for some reason:

```
root@master:~ [1]# kubectl apply -f demo-api.yaml
error: error validating "demo-api.yaml": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "restartPolicy" in io.k8s.api.core.v1.Container; if you choose to ignore these errors, turn validation off with --validate=false
```