### PR TITLE
Remove Docker update steps from scenario setup

### DIFF
--- a/kube-sec-deploy/preload-images.sh
+++ b/kube-sec-deploy/preload-images.sh
@@ -20,41 +20,6 @@ docker pull alpine:3.4
 # Make Clair database deploy script executable (Katacoda doesn't preserve file permissions)
 chmod a+x deploy_db.sh
 
-docker version 
-# Update docker (so we have a version with `docker trust` commands)
-systemctl stop kubelet
-apt-get update &&
-apt-get remove -y docker docker-engine docker.io containerd runc &&
-apt-get update &&
-apt-get install -y \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg-agent \
-        software-properties-common \
-        tree &&
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - &&
-add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) \
-    stable" &&
-apt-get update &&
-mv /etc/docker/daemon.json /etc/docker/daemon-old.json &&
-mv daemon.json /etc/docker/daemon.json &&
-apt-get install -y docker-ce docker-ce-cli containerd.io &&
-echo "Docker Upgrade Complete" &&
-mv /etc/docker/daemon-old.json /etc/docker/daemon.json &&
-# Remove '-H fd://' from the command invocation of the docker service as it conflicts with the `daemon.json`
-sed 's/\ \-H\ fd\:\/\///g' /lib/systemd/system/docker.service > /lib/systemd/system/docker-new.service &&
-mv /lib/systemd/system/docker-new.service /lib/systemd/system/docker.service &&
-cat /etc/docker/daemon.json | jq '.["insecure-registries"] += ["127.0.0.1/8"]' > /etc/docker/daemon-new.json &&
-mv /etc/docker/daemon-new.json /etc/docker/daemon.json &&
-systemctl daemon-reload &&
-systemctl restart docker &&
-echo "Docker Restarted" &&
-systemctl start kubelet &&
-echo "Kubelet Restarted" &&
-
 # Pull down a Clair DB so we can push it into the container later and don't need to wait for it to autoupdate
 curl -O https://raw.githubusercontent.com/s-irvine/katacoda-test/master/kube-sec-deploy/assets/clair-db/clear.sql &&
 curl -O https://raw.githubusercontent.com/s-irvine/katacoda-test/master/kube-sec-deploy/assets/clair-db/vulnerability.sql &&


### PR DESCRIPTION
These are no longer needed as the `kubernetes` backend now comes with Docker `18.09.5` which includes the required `trust` command.

I've tested all steps in a forked scenario and it behaves as expected.