### PR TITLE
Documentation updates

### DIFF
--- a/kube-sec-deploy/03-Image-Signing.md
+++ b/kube-sec-deploy/03-Image-Signing.md
@@ -122,7 +122,7 @@ When you sign an image, the unsigned versions of the image are still present in 
     Failed to pull image "127.0.0.1:30002/library/demo-api:vulnerable": rpc error: code = Unknown desc = Error response from daemon: unknown:  The image is not signed in Notary.
     ```
 
-1. Change the deployment yaml `demo-api.yaml` to reference your signed, secure image, with the `secure` tag and redeploy:  
+1. Change the deployment yaml `demo-api.yaml` to reference your signed, secure image, with the `signed` tag and redeploy:  
     `vi demo-api.yaml`{{execute}}  
     `kubectl apply -f demo-api.yaml`{{execute}}
 

--- a/kube-sec-deploy/04-Kubesec.md
+++ b/kube-sec-deploy/04-Kubesec.md
@@ -38,7 +38,7 @@ curl --silent \
 https://kubesec.io/
 }
 kubesec ./test/deployment.yaml
-```{{copy}}
+```{{execute}}
 > all sensitive configuration should live in `secrets` -  never leak configuration to a remote service.
 1. The problem is `containers[] .securityContext .privileged == true` - running a privileged pod.  
 Although this is dangerous, perhaps we have an "urgent business requirement" (:facepalm:). Let's edit the admission controller to allow an insecure deployment:  
@@ -46,10 +46,10 @@ Although this is dangerous, perhaps we have an "urgent business requirement" (:f
 `kubectl delete -f deploy/webhook.yaml`{{execute}}
 `kubectl create -f deploy/webhook.yaml`{{execute}}
 1. Now anything with a score above `-100` will be allowed into the cluster! This is a bad thing. Let's test it:  
-`kubectl apply -f ./test/deployment.yaml`  
+`kubectl apply -f ./test/deployment.yaml`{{execute}}
 Our deployment has just been created despite failing the checks.
 1. Now that we've deployed an insecure pod, let's change the admission controller risk threshold back to `0`.  
-`sed -i 's,-min-score=.*,-min-score=0,' deploy/webhook.yaml`
+`sed -i 's,-min-score=.*,-min-score=0,' deploy/webhook.yaml`{{execute}}
 `kubectl delete -f deploy/webhook.yaml`{{execute}}
 `kubectl create -f deploy/webhook.yaml`{{execute}}
 `kubectl get pods --selector=app=nginx`{{execute}}

--- a/kube-sec-deploy/04-Kubesec.md
+++ b/kube-sec-deploy/04-Kubesec.md
@@ -10,7 +10,7 @@ Kubesec identifies security risks in your Kubernetes configuration and quantifie
 `kubectl label namespaces default kubesec-validation=enabled`{{execute}}  
 This deploys a `kubesec-webhook` pod in the `kubesec` namespace, a webhook admission controller configuration for the API server, and the secrets for secure communication.
 1. Examine the webhook admission controller that's just been deployed:  
-less deploy/webhook-registration.yaml`{{execute}}
+`less deploy/webhook-registration.yaml`{{execute}}
 1. Find the `namespaceSelector` that corresponds to the label applied to the `default` namespace above. This is the only link between the admission controller and a namespace.  
 Notice a CA bundle is required. This is because pod manifests may contain secrets in environment variables, or sensitive information about itself or other services. To ensure that the Kubernetes API trusts the admission controller, the CA bundle of the HTTPS endpoint that the API server POSTs to must be declared to establish a trust relationship between them.  
 The secrets that are mounted into the admission controller are in `webhook-certs.yaml`, and the actual pod that's deployed is in `webhook.yaml`.


### PR DESCRIPTION
This PR fixes the reference to the `signed` tag in the Image Signing section, it also marks some additional commands as `{{execute}}` for convenience. I've tested these in a forked scenario.